### PR TITLE
add labels and ability to compare labels/annotations with its values

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Flag | Environment Variable | Type | Default | Required | Description
 ---- | -------------------- | ---- | ------- | -------- | -----------
 `log-level` | `LOG_LEVEL` | `string` | `info` | no | The level of log detail.
 `bind-address` | `BIND_ADDRESS` | `string` | `:9797` | no | The address for binding listener.
-`node-taint` | `NODE_TAINT` | `string` | | yes |  The startup taint to put on node.
-`daemonset-annotation` | `DAEMONSET_ANNOTATION` | `string` | | yes | The annotation of required daemonset.
- 
- 
+`node-taint` | `NODE_TAINT` | `string` | | yes |  The startup taint to remove from node.
+`daemonset-annotation` | `DAEMONSET_ANNOTATION` | `string` | | yes | The annotations of required daemonset, eg. key1:val1,key2:val2,key3.
+`daemonset-label` | `DAEMONSET_LABEL` | `string` | | yes | The labels of required daemonset, eg. key1:val1,key2:val2,key3.
+

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ package config
 type Ops struct {
 	LogLevel            string `long:"log-level" env:"LOG_LEVEL" description:"Log level" default:"info"`
 	NodeTaint           string `long:"node-taint" env:"NODE_TAINT" description:"The node taints that's going to remove."`
-	DaemonSetAnnotation string `long:"daemonset-annotation" env:"DAEMONSET_ANNOTATION" description:"The annotation of the daemonset to watch"`
+	DaemonSetAnnotation string `long:"daemonset-annotation" env:"DAEMONSET_ANNOTATION" description:"The annotation of the daemonset to watch, key:value pairs, comma delemited"`
 	BindAddr            string `long:"bind-address" short:"p" env:"BIND_ADDRESS" default:":9797" description:"address for binding metrics listener"`
+	DaemonSetLabel      string `long:"daemonset-label" env:"DAEMONSET_LABEL" description:"The label of the daemonset to watch, key:value pairs, comma delemited"`
 }


### PR DESCRIPTION
Hi this PR, introduce same for labels. We need labels becuase you cannot edit kops addons annotations. It allows you to use multiple annotations and multiple lables together to match desired daemonset. It support annotations/lables values as well. Synax for env var is  DAEMONSET_ANNOTATION: "key1:val1,key2:val2,key3"  key3 without value just check presence of annotation for backward compatibility.